### PR TITLE
fix a bug when playing sound

### DIFF
--- a/source/drivers/sound/main.c
+++ b/source/drivers/sound/main.c
@@ -139,7 +139,7 @@ void task_refill_sound_buffer(void) {
   }
  }
  else {
-  if(sound_get_actual_stream_position()>sound_buffer_refilling_info->buffer_size) {
+  if(sound_get_actual_stream_position()>=sound_buffer_refilling_info->buffer_size) {
    sound_buffer_refilling_info->played_bytes = (sound_buffer_refilling_info->played_bytes_by_finished_buffers+sound_get_actual_stream_position()-sound_buffer_refilling_info->buffer_size);
   }
   else {


### PR DESCRIPTION
When I tried to play on VBox, I found that it can't play fully, then I found that the `played_bytes` might be the same as `buffer_size`. This will cause it to do nothing but loop in two branches, and finally the played size will be more than the `size_of_full_pcm_output_in_bytes`, so it calls `stop_sound()`, the card stop playing the pcm data. and in fact, the pcm data isn't played fully.